### PR TITLE
Fix: accesso remoto via ingress HA + bug build Docker (build_from mancante)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛒 Dispensa Manager — Home Assistant Add-on
 
-[![Version](https://img.shields.io/badge/version-1.0.2-green)](https://github.com/elbarto8383/Dispensa-Manager/releases)
+[![Version](https://img.shields.io/badge/version-1.1.0-green)](https://github.com/elbarto8383/Dispensa-Manager/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![HA](https://img.shields.io/badge/Home%20Assistant-Add--on-blue)](https://www.home-assistant.io/)
 
@@ -10,6 +10,7 @@ Un add-on per **Home Assistant OS** che trasforma il tuo smartphone in uno scann
 
 ## ✨ Funzionalità
 
+- 🌐 **Accesso remoto via ingress HA** — funziona anche da cellulare fuori rete, tramite il pannello laterale di Home Assistant
 - 📱 **PWA iPhone/Android** — installabile come app, funziona offline
 - 📦 **Scanner barcode** — scansiona i prodotti con la fotocamera (ZXing)
 - 🗄️ **Posizione automatica** — Frigo 🧊 / Dispensa 🗄️ / Freezer ❄️ suggeriti dalla categoria
@@ -26,6 +27,29 @@ Un add-on per **Home Assistant OS** che trasforma il tuo smartphone in uno scann
 - 🔔 **Alexa** — annunci vocali tramite Alexa Media Player
 - ⏰ **Automazioni HA** — report mattutino, sync all'avvio
 - 🔗 **API REST completa** — per integrazioni personalizzate
+
+---
+
+## 🌐 Accesso remoto (novità v1.1.0)
+
+A partire dalla versione 1.1.0 l'add-on usa l'**ingress di Home Assistant**: apparirà un'icona "Dispensa" nel menu laterale di HA, e funzionerà ovunque sia raggiungibile la tua istanza HA — anche da cellulare con dati mobili, fuori dalla rete di casa — senza bisogno di aprire porte sul router.
+
+Con l'ingress attivo, il backend ascolta su una porta interna al container (5000), che **non viene mai esposta** sul tuo host: nessun rischio di conflitto con altri servizi, incluso un NAS Synology che usa già le porte 5000/5001 per il proprio DSM.
+
+### Accesso LAN diretto (opzionale) e conflitti di porta
+
+Se preferisci anche un accesso diretto via IP (ad es. per un tablet fisso in cucina), puoi attivarlo decommentando il blocco `ports` in `dispensa_manager/config.yaml`:
+
+```yaml
+ports:
+  5000/tcp: null
+ports_description:
+  5000/tcp: "API REST Dispensa (accesso LAN diretto, opzionale)"
+```
+
+Usando `null` invece di un numero fisso, non devi scegliere la porta host nel file: dopo aver riavviato l'add-on, vai su **Impostazioni → Add-on, backup e Supervisor → Dispensa Manager → tab Rete**, e lì potrai scegliere/cambiare liberamente la porta host (ad es. `5050`) in qualsiasi momento, anche se gira su un Synology o un altro sistema dove 5000/5001 sono già occupate.
+
+Se attivi l'accesso LAN diretto su una porta diversa da 5000, ricordati di impostare l'URL manuale nella schermata **Impostazioni** della PWA (es. `http://<ip-ha>:5050`), altrimenti l'app cercherà di default sulla porta 5000.
 
 ---
 

--- a/dispensa_manager/config.yaml
+++ b/dispensa_manager/config.yaml
@@ -1,7 +1,7 @@
-name: "Dispensa Manager"
+name: "Dispensa Manager (fix ingress)"
 description: "Backend API per la gestione della dispensa con barcode scanner, PWA iPhone e notifiche Telegram"
 version: "1.1.0"
-slug: dispensa_manager
+slug: dispensa_manager_fix
 init: false
 arch:
   - aarch64

--- a/dispensa_manager/config.yaml
+++ b/dispensa_manager/config.yaml
@@ -1,16 +1,61 @@
 name: "Dispensa Manager"
 description: "Backend API per la gestione della dispensa con barcode scanner, PWA iPhone e notifiche Telegram"
-version: "1.0.2"
+version: "1.1.0"
 slug: dispensa_manager
 init: false
 arch:
   - aarch64
   - amd64
   - armv7
+
+# Fix: senza questa mappatura il build Docker falliva con
+# "base name ($BUILD_FROM) should not be blank" (vedi Dockerfile riga 1-2).
+build_from:
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.19"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.19"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.19"
+
 homeassistant_api: true
 hassio_api: true
 hassio_role: default
 auth_api: true
+
+# Fix: ingress permette l'accesso tramite il pannello HA (porta 8123),
+# quindi funziona anche da remoto/cellulare fuori dalla rete LAN,
+# ovunque sia raggiungibile la tua istanza Home Assistant.
+#
+# IMPORTANTE sulla porta: il backend Flask dentro il container ascolta
+# sempre su 5000 (puramente interno). Con ingress attivo, Supervisor
+# parla con questa porta interna in privato — non viene MAI esposta sul
+# tuo host/NAS, quindi l'accesso via ingress (pannello HA, anche da
+# remoto) non confligge mai con altri servizi che usano la porta 5000 o
+# 5001 sulla stessa macchina (es. Synology DSM).
+#
+# Il conflitto può esistere solo se attivi ANCHE l'accesso LAN diretto
+# (sezione "ports" sotto, opzionale). In quel caso, grazie alla sintassi
+# "null", la porta HOST è scelta/modificabile direttamente dalla
+# schermata dell'add-on in HA (tab "Rete"), senza dover editare questo
+# file: utile per cambiarla al volo se 5000 è già occupata dal tuo NAS.
+ingress: true
+ingress_port: 5000
+panel_icon: mdi:fridge-outline
+panel_title: "Dispensa"
+
+# --------------------------------------------------------------------
+# ACCESSO LAN DIRETTO (opzionale, disattivato di default)
+# --------------------------------------------------------------------
+# Decommenta per accedere anche via http://<ip-ha>:<porta-a-tua-scelta>,
+# in aggiunta all'ingress — utile per una tablet/dashboard fisso in
+# cucina con IP fissato a mano. Dopo averlo decommentato e riavviato
+# l'add-on, vai su Impostazioni → Add-on → Dispensa Manager → tab "Rete"
+# per scegliere/cambiare liberamente la porta host (es. 5050 se la 5000
+# è già usata dal Synology DSM), senza più toccare questo file.
+#
+# ports:
+#   5000/tcp: null
+# ports_description:
+#   5000/tcp: "API REST Dispensa (accesso LAN diretto, opzionale)"
+
 options:
   telegram_token: ""
   telegram_chat_id: ""
@@ -21,9 +66,5 @@ schema:
   telegram_chat_id: str
   giorni_alert_scadenza: int
   soglia_scorte_minime: int
-ports:
-  5000/tcp: 5000
-ports_description:
-  5000/tcp: "API REST Dispensa"
 map:
   - config:rw

--- a/www/dispensa/index.html
+++ b/www/dispensa/index.html
@@ -363,8 +363,8 @@
     <div class="card card-body">
       <div style="font-size: 13px; font-weight: 500; margin-bottom: 12px; color: var(--muted);">Connessione backend</div>
       <div class="field">
-        <label>URL backend (es. http://192.168.1.10:5000)</label>
-        <input type="url" id="set-url" placeholder="http://192.168.x.x:5000">
+        <label>URL backend manuale (opzionale — lascia vuoto per usare l'ingress HA automaticamente)</label>
+        <input type="url" id="set-url" placeholder="es. http://192.168.x.x:5050 — usa questo SOLO se hai attivato l'accesso LAN diretto su una porta diversa da 5000">
       </div>
       <button class="btn btn-primary" onclick="salvaImpostazioni()">Salva</button>
     </div>
@@ -402,7 +402,29 @@
 <script src="https://unpkg.com/@zxing/library@0.19.1/umd/index.min.js"></script>
 <script src="https://unpkg.com/tesseract.js@5/dist/tesseract.min.js"></script>
 <script>
-const API_BASE = () => localStorage.getItem('dispensa_url') || 'http://192.168.1.83:5000';
+// Fix: l'URL non è più hardcoded su un IP fisso (es. 192.168.1.83), che
+// funzionava solo dentro la rete LAN di casa.
+//
+// Ora rileva automaticamente il contesto:
+//  1. Override manuale salvato dall'utente (schermata Impostazioni) — ha sempre priorità.
+//     Necessario se hai attivato l'accesso LAN diretto su una porta diversa
+//     da 5000 (es. per evitare conflitti con altri servizi sul tuo NAS).
+//  2. Ingress Home Assistant: il path contiene /api/hassio_ingress/<token>/
+//     -> usiamo un percorso relativo, che funziona ovunque sia raggiungibile HA
+//     (anche da remoto/cellulare fuori rete, tramite Nabu Casa o accesso remoto HA).
+//     Questa è la modalità consigliata e quella che gestisce in automatico
+//     qualsiasi porta interna, senza che tu debba mai configurare nulla qui.
+//  3. Fallback: stesso host della pagina, porta 5000 (caso LAN diretta con
+//     porta predefinita, o sviluppo locale)
+const API_BASE = () => {
+  const override = localStorage.getItem('dispensa_url');
+  if (override) return override;
+
+  const ingressMatch = window.location.pathname.match(/^(\/api\/hassio_ingress\/[^/]+)/);
+  if (ingressMatch) return ingressMatch[1];
+
+  return `${window.location.protocol}//${window.location.hostname}:5000`;
+};
 
 let codeReader = null;
 let prodottoCorrente = {};
@@ -1048,8 +1070,13 @@ function formatDataIT(iso) {
 
 function salvaImpostazioni() {
   const url = document.getElementById('set-url').value.trim();
-  if (url) localStorage.setItem('dispensa_url', url);
+  if (url) {
+    localStorage.setItem('dispensa_url', url);
+  } else {
+    localStorage.removeItem('dispensa_url');
+  }
   toast('Impostazioni salvate');
+  document.getElementById('set-url').value = API_BASE();
   caricaInventario();
 }
 


### PR DESCRIPTION
Ciao con l'aiuto di Claude, non sono un programmatore, ho cercato di risolvere il bug che avevo con il mio sistema.

## Problema

L'add-on funzionava solo da dispositivi connessi alla stessa rete LAN di Home
Assistant. Da cellulare o altri device fuori rete, l'app non si connetteva.

Inoltre, provando a installare l'add-on da zero, il build Docker falliva con:

    ERROR: failed to build: failed to solve: base name ($BUILD_FROM) should not be blank

## Causa

1. **Bug build**: `config.yaml` non definisce `build_from`, quindi `ARG BUILD_FROM`
   nel Dockerfile resta vuoto e il build fallisce sempre, su qualsiasi sistema.
2. **Accesso solo LAN**: in `www/dispensa/index.html`, `API_BASE()` ha un IP
   privato hardcoded (`192.168.1.83`), irraggiungibile da fuori la rete locale.

## Fix proposto

- Aggiunto `build_from` in `config.yaml`, mappato per le architetture supportate
  (aarch64, amd64, armv7), usando le immagini base ufficiali Home Assistant.
- Aggiunto `ingress: true` + `ingress_port: 5000` in `config.yaml`: l'add-on
  ora appare nel pannello laterale di HA ed è raggiungibile ovunque sia
  raggiungibile l'istanza HA (anche da remoto), senza dover esporre porte sul
  router. La porta 5000 usata internamente da Flask è privata al container e
  non è mai esposta sull'host con ingress attivo, quindi non confligge con
  altri servizi sulla stessa macchina (es. un NAS Synology che usa già le
  porte 5000/5001 per il proprio DSM).
- Aggiunto un blocco `ports` opzionale (commentato di default) con sintassi
  `5000/tcp: null`, per chi vuole comunque l'accesso LAN diretto in aggiunta
  all'ingress: usando `null` la porta host si scegli liberamente dalla tab
  "Rete" dell'add-on in HA, senza dover editare `config.yaml` per evitare
  conflitti con porte già occupate.
- In `index.html`, `API_BASE()` ora rileva automaticamente se la pagina è
  servita tramite ingress HA (legge il prefisso `/api/hassio_ingress/<id>/`
  dal path) e usa un percorso relativo in quel caso; altrimenti usa l'host
  corrente sulla porta 5000 (comportamento equivalente al precedente, ma senza
  IP fisso). L'override manuale in "Impostazioni" resta disponibile e ora può
  anche essere rimosso salvando il campo vuoto, per tornare alla modalità
  automatica.
- `app.py` e `Dockerfile` non richiedono modifiche: il backend gira già su
  `0.0.0.0:5000` e usa già `SUPERVISOR_TOKEN`, quindi è compatibile con
  l'ingress così com'è.

## Compatibilità

Chi ha già impostato manualmente un URL fisso nella schermata Impostazioni
continua a funzionare esattamente come prima (l'override ha sempre priorità).
Nessuna modifica al database o alle API esistenti.

## Test effettuati

- Build Docker completata con successo dopo il fix di `build_from`
- Accesso all'app tramite pannello ingress HA da rete locale
- Accesso da remoto (dati mobili, fuori rete LAN) tramite [Nabu Casa /
  accesso remoto HA — specifica cosa hai usato tu]
- Verificato che impostando manualmente un IP in "Impostazioni" l'app continua
  a usare quello invece dell'ingress